### PR TITLE
add CTF to output

### DIFF
--- a/cryosparc2/protocols/protocol_cryosparc_part_subtract.py
+++ b/cryosparc2/protocols/protocol_cryosparc_part_subtract.py
@@ -186,9 +186,12 @@ class ProtCryoSparcSubtract(ProtCryosparcBase, ProtOperateParticles):
     def _fillDataFromIter(self, imgSet):
 
         outImgsFn = 'particles@' + self._getFileName('out_particles')
+        hasCtf = imgSet.hasCTF()
+        hasAcquisition = True  # I think this is alway present ROB
         readSetOfParticles(outImgsFn, imgSet,
                            postprocessImageRow=self._updateItem,
-                           alignType=ALIGN_PROJ)
+                           alignType=ALIGN_PROJ, readCtf=hasCtf, 
+                           readAcquisition= hasAcquisition)
 
     def _updateItem(self, item, row):
         newFn = row.get(RELIONCOLUMNS.rlnImageName.value)


### PR DESCRIPTION
copy CTF information from input particles to output particles. At present CTF information is lost and, since the id of input and out images is different, it is not easy to put it back.

Note:  the input and out images are in different order. In particular for a 13498 particles
de following assignation is done:

  sparc                        scipion
particle No                 particle No
1                                          2
2                                          4
6749 = 13498/2.           13498

6750                                     1
6751                                    3