### PR TITLE
update the way the outfile names are computed

### DIFF
--- a/cryosparc2/protocols/protocol_cryosparc_3D_classification.py
+++ b/cryosparc2/protocols/protocol_cryosparc_3D_classification.py
@@ -274,9 +274,9 @@ class ProtCryoSparc3DClassification(ProtCryosparcBase):
                               self.run3dClassification.get())
         itera = self.findLastIteration(self.run3dClassification.get())
 
-        csParticlesName = "cryosparc_%s_%s_000%s_particles.cs" % (self.projectName.get(),
+        csParticlesName = "cryosparc_%s_%s_%05d_particles.cs" % (self.projectName.get(),
                                                                  self.run3dClassification.get(),
-                                                                 itera)
+                                                                 int(itera))
         # Copy the CS output particles to extra folder
         copyFiles(csOutputFolder, self._getExtraPath(), files=[csParticlesName])
 
@@ -366,15 +366,15 @@ class ProtCryoSparc3DClassification(ProtCryosparcBase):
             output_file.write('\n')
             numOfClass = len(self.importVolumes)
             for i in range(numOfClass):
-                csVolName = ("cryosparc_%s_%s_class_%02d_000%s_volume.mrc" %
+                csVolName = ("cryosparc_%s_%s_class_%02d_%05d_volume.mrc" %
                              (self.projectName.get(),
-                              self.run3dClassification.get(), i, itera))
+                              self.run3dClassification.get(), i, int(itera)))
 
                 copyFiles(csOutputFolder, self._getExtraPath(), files=[csVolName])
 
-                row = ("%s/cryosparc_%s_%s_class_%02d_000%s_volume.mrc\n" %
+                row = ("%s/cryosparc_%s_%s_class_%02d_%05d_volume.mrc\n" %
                        (self._getExtraPath(), self.projectName.get(),
-                        self.run3dClassification.get(), i, itera))
+                        self.run3dClassification.get(), i, int(itera)))
                 output_file.write(row)
 
     def findLastIteration(self, jobName):

--- a/cryosparc2/protocols/protocol_cryosparc_new_3D_classification.py
+++ b/cryosparc2/protocols/protocol_cryosparc_new_3D_classification.py
@@ -350,10 +350,11 @@ class ProtCryoSparcNew3DClassification(ProtCryosparcBase):
                                       self.run3dClassification.get())
         itera = self.findLastIteration(self.run3dClassification.get())
 
-        csParticlesName = "cryosparc_%s_%s_00%s_particles.cs" % (
+        #00037:   Unable to execute the copy: Files or directory does not exist:  [Errno 2] No such file or directory: '/home/roberto/cryoSPARC/scipion_projects/2022_06_20_mx2369_pkv-carmen/P3/J188/cryosparc_P3_J188_001754_particles.cs'
+        csParticlesName = "cryosparc_%s_%s_%05d_particles.cs" % (
                                                  self.projectName.get(),
                                                  self.run3dClassification.get(),
-                                                 itera)
+                                                 int(itera))
         # Copy the CS output particles to extra folder
         copyFiles(csOutputFolder, self._getExtraPath(), files=[csParticlesName])
 
@@ -459,16 +460,16 @@ class ProtCryoSparcNew3DClassification(ProtCryosparcBase):
             output_file.write('\n')
             numOfClass = self.class3D_N_K.get()
             for i in range(numOfClass):
-                csVolName = ("cryosparc_%s_%s_class_%02d_00%s_volume.mrc" %
+                csVolName = ("cryosparc_%s_%s_class_%02d_%05d_volume.mrc" %
                              (self.projectName.get(),
-                              self.run3dClassification.get(), i, itera))
+                              self.run3dClassification.get(), i, int(itera)))
 
                 copyFiles(csOutputFolder, self._getExtraPath(),
                           files=[csVolName])
 
-                row = ("%s/cryosparc_%s_%s_class_%02d_00%s_volume.mrc\n" %
+                row = ("%s/cryosparc_%s_%s_class_%02d_%05d_volume.mrc\n" %
                        (self._getExtraPath(), self.projectName.get(),
-                        self.run3dClassification.get(), i, itera))
+                        self.run3dClassification.get(), i, int(itera)))
                 output_file.write(row)
 
     def findLastIteration(self, jobName):


### PR DESCRIPTION
When executing different cryosparc protocols I get error messages similar to:

#00037:   Unable to execute the copy: Files or directory does not exist:  [Errno 2] No such file or directory: '/home/roberto/cryoSPARC/scipion_projects/2022_06_20_mx2369_pkv-carmen/P3/J188/cryosparc_P3_J188_001754_particles.cs'

That is, cryosparc has finished and produced the output but scipion cannot find them. After closer inspection it seems that the name of the output filename is wrong. That is, scipion searches for "cryosparc_P3_J188_001754_particles.cs" but the actual name is "cryosparc_P3_J188_01754_particles.cs" (there was an extra zero).

I have changed the code so lines as

        csParticlesName = "cryosparc_%s_%s_00%s_particles.cs" % (
become
        csParticlesName = "cryosparc_%s_%s_%05d_particles.cs" % (

This solved my problem but I do not know if it will be OK in all cases. 

In summary: under some conditions the actual code produces output file names that are wrong. This pull request fixes the problem for my particular case but a more systematic check is recommended.

   

