### PR TITLE
change 00%s by .zfill(5)

### DIFF
--- a/cryosparc2/protocols/protocol_cryosparc_new_3D_classification.py
+++ b/cryosparc2/protocols/protocol_cryosparc_new_3D_classification.py
@@ -327,11 +327,10 @@ class ProtCryoSparcNew3DClassification(ProtCryosparcBase):
         csOutputFolder = os.path.join(self.projectDir.get(),
                                       self.run3dClassification.get())
         itera = self.findLastIteration(self.run3dClassification.get())
-
-        csParticlesName = "%s%s_00%s_particles.cs" % (
+        csParticlesName = "%s%s_%s_particles.cs" % (
                                                  getOutputPreffix(self.projectName.get()),
                                                  self.run3dClassification.get(),
-                                                 itera)
+                                                 itera.zfill(5))
         csPassParticles = "%s_passthrough_particles_all_classes.cs" % self.run3dClassification.get()
 
         # Copy the CS output particles to extra folder
@@ -439,16 +438,16 @@ class ProtCryoSparcNew3DClassification(ProtCryosparcBase):
             output_file.write('\n')
             numOfClass = self.class3D_N_K.get()
             for i in range(numOfClass):
-                csVolName = ("%s%s_class_%02d_00%s_volume.mrc" %
+                csVolName = ("%s%s_class_%02d_%s_volume.mrc" %
                              (getOutputPreffix(self.projectName.get()),
-                              self.run3dClassification.get(), i, itera))
+                              self.run3dClassification.get(), i, itera.zfill(5)))
 
                 copyFiles(csOutputFolder, self._getExtraPath(),
                           files=[csVolName])
 
-                row = ("%s/%s%s_class_%02d_00%s_volume.mrc\n" %
+                row = ("%s/%s%s_class_%02d_%s_volume.mrc\n" %
                        (self._getExtraPath(), getOutputPreffix(self.projectName.get()),
-                        self.run3dClassification.get(), i, itera))
+                        self.run3dClassification.get(), i, itera.zfill(5)))
                 output_file.write(row)
 
     def findLastIteration(self, jobName):


### PR DESCRIPTION
In the current version the name of the cryosparc output files (for example metadata file with particles) is obtained using a line as:

        csParticlesName = "%s%s_00%s_particles.cs" % 

In particular we compute 
       "00%s" % itera 

That is, there is substring that always contains two leading "0".  In general, this assumption is not correct. 
The substring needed is a substring with 5 characters that satisfies
      itera.zfill(5))
Therefore if "len(itera)" is less than 5 leading "0" should be added. In particular if len(itera)==4 only one zero need to be added

Note that for projects with a small number of cryosparc protocols, itera has always 3 characters and 

    "00%s" % itera 

works

But for projects with many cryosparc protocols (in our case 12) 
        itera.zfill(5))
is needed

============
Note: I have not checked but I guess protocol_cryosparc_3D_classification.py may present the same problem