### PR TITLE
Update cs2Start.py

### DIFF
--- a/cryosparc2/convert/cs2Start.py
+++ b/cryosparc2/convert/cs2Start.py
@@ -11,6 +11,8 @@ def cs2Star(args):
     import logging
     from pyem import metadata
     from pyem import star
+    # see https://numpy.org/doc/stable/reference/generated/numpy.load.html
+    # for an explanation of MAX_HEADER_SIZE
     MAX_HEADER_SIZE = 50000
 
     log = logging.getLogger('root')

--- a/cryosparc2/convert/cs2Start.py
+++ b/cryosparc2/convert/cs2Start.py
@@ -11,6 +11,7 @@ def cs2Star(args):
     import logging
     from pyem import metadata
     from pyem import star
+    MAX_HEADER_SIZE = 50000
 
     log = logging.getLogger('root')
     hdlr = logging.StreamHandler(sys.stdout)
@@ -24,7 +25,7 @@ def cs2Star(args):
 
     if args.input[0].endswith(".cs"):
         log.debug("Detected CryoSPARC 2+ .cs file")
-        cs = np.load(args.input[0])
+        cs = np.load(args.input[0], max_header_size=MAX_HEADER_SIZE)
         if args.first10k:
             cs = cs[:10000]
 


### PR DESCRIPTION
For large datasets (4 millions particles) convert step fails with error:

----
(pyem-23.01.25) marta@asimov-tres:~$ python3 /home/marta/scipion/Plugin3/scipion-em-cryosparc2/cryosparc2/convert/cs2Start.py /data/marta/Adeno-core_local/Runs/067309_ProtCryoSparcNew3DClassification/extra/J4_00468_particles.cs /data/marta/Adeno-core_local/Runs/067309_ProtCryoSparcNew3DClassification/extra/output_particle_2.star
Traceback (most recent call last):
  File "/home/marta/scipion/Plugin3/scipion-em-cryosparc2/cryosparc2/convert/cs2Start.py", line 220, in <module>
    sys.exit(cs2Star(args))
  File "/home/marta/scipion/Plugin3/scipion-em-cryosparc2/cryosparc2/convert/cs2Start.py", line 27, in cs2Star
    cs = np.load(args.input[0], max_header_size=MAX_HEADER_SIZE)
  File "/home/marta/miniconda/envs/pyem-23.01.25/lib/python3.8/site-packages/numpy/lib/npyio.py", line 432, in load
    return format.read_array(fid, allow_pickle=allow_pickle,
  File "/home/marta/miniconda/envs/pyem-23.01.25/lib/python3.8/site-packages/numpy/lib/format.py", line 765, in read_array
    shape, fortran_order, dtype = _read_array_header(
  File "/home/marta/miniconda/envs/pyem-23.01.25/lib/python3.8/site-packages/numpy/lib/format.py", line 599, in _read_array_header
    raise ValueError(
ValueError: Header info length (15478) is large and may not be safe to load securely.  <<<<<<<<<<<<<<<<<<<
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
To allow loading, adjust `max_header_size` or fully trust the `.npy` file using `allow_pickle=True`.
For safety against large resource use or crashes, sandboxing may be necessary.

----
The problem is in the cs2start.py file, when np tries to load the metadata file it fails because the size of the header of this file is larger than the maximum header file defined by np. The default is 10000B, the required 15000B. In this pull request the default size is increased from 10000 to 50000.

By the way, please please check the other pending pull request. 