### PR TITLE
Cryosparc working with queue system

### DIFF
--- a/cryosparc2/protocols/protocol_cryosparc2d.py
+++ b/cryosparc2/protocols/protocol_cryosparc2d.py
@@ -457,8 +457,12 @@ class ProtCryo2D(ProtCryosparcBase, pwprot.ProtClassify2D):
         # Determinate the GPUs or the number of GPUs to use (in dependence of
         # the cryosparc version)
         try:
-            gpusToUse = self.getGpuList()
-            numberGPU = len(gpusToUse)
+            if not self.useQueueForSteps() and not self.useQueue(): # not using queue system
+                gpusToUse = self.getGpuList()
+                numberGPU = len(gpusToUse)
+            else: # using queue system
+                gpusToUse = False
+                numberGPU = 1
         except Exception:
             gpusToUse = False
             numberGPU = 1

--- a/cryosparc2/protocols/protocol_cryosparc_3D_classification.py
+++ b/cryosparc2/protocols/protocol_cryosparc_3D_classification.py
@@ -494,7 +494,10 @@ class ProtCryoSparc3DClassification(ProtCryosparcBase):
         # Determinate the GPUs to use (in dependence of
         # the cryosparc version)
         try:
-            gpusToUse = self.getGpuList()
+            if not self.useQueueForSteps() and not self.useQueue():  # not using queue system
+                gpusToUse = self.getGpuList()
+            else:  # using queue system
+                gpusToUse = False
         except Exception:
             gpusToUse = False
 

--- a/cryosparc2/protocols/protocol_cryosparc_3D_flex_generator.py
+++ b/cryosparc2/protocols/protocol_cryosparc_3D_flex_generator.py
@@ -120,7 +120,10 @@ class ProtCryoSparc3DFlexGenerator(ProtCryosparcBase, ProtFlexBase):
         self._className = "flex_generate"
 
         try:
-            gpusToUse = self.getGpuList()
+            if not self.useQueueForSteps() and not self.useQueue():  # not using queue system
+                gpusToUse = self.getGpuList()
+            else:  # using queue system
+                gpusToUse = False
         except Exception:
             gpusToUse = False
 

--- a/cryosparc2/protocols/protocol_cryosparc_3D_flex_reconstruction.py
+++ b/cryosparc2/protocols/protocol_cryosparc_3D_flex_reconstruction.py
@@ -170,7 +170,10 @@ class ProtCryoSparc3DFlexReconstruction(ProtCryosparcBase):
     def doRun3DFlexReconstruction(self):
         self._className = "flex_highres"
         try:
-            gpusToUse = self.getGpuList()
+            if not self.useQueueForSteps() and not self.useQueue():  # not using queue system
+                gpusToUse = self.getGpuList()
+            else:  # using queue system
+                gpusToUse = False
         except Exception:
             gpusToUse = False
 

--- a/cryosparc2/protocols/protocol_cryosparc_3D_flex_training.py
+++ b/cryosparc2/protocols/protocol_cryosparc_3D_flex_training.py
@@ -266,7 +266,10 @@ class ProtCryoSparc3DFlexTraining(ProtCryosparcBase, ProtFlexBase):
         self._className = "flex_train"
 
         try:
-            gpusToUse = self.getGpuList()
+            if not self.useQueueForSteps() and not self.useQueue():  # not using queue system
+                gpusToUse = self.getGpuList()
+            else:  # using queue system
+                gpusToUse = False
         except Exception:
             gpusToUse = False
 

--- a/cryosparc2/protocols/protocol_cryosparc_3d_variability.py
+++ b/cryosparc2/protocols/protocol_cryosparc_3d_variability.py
@@ -302,7 +302,10 @@ class ProtCryoSparc3DVariability(ProtCryosparcBase, ProtRefine3D):
         # Determinate the GPUs to use (in dependence of
         # the cryosparc version)
         try:
-            gpusToUse = self.getGpuList()
+            if not self.useQueueForSteps() and not self.useQueue():  # not using queue system
+                gpusToUse = self.getGpuList()
+            else:  # using queue system
+                gpusToUse = False
         except Exception:
             gpusToUse = False
 

--- a/cryosparc2/protocols/protocol_cryosparc_3d_variability_display.py
+++ b/cryosparc2/protocols/protocol_cryosparc_3d_variability_display.py
@@ -526,7 +526,10 @@ class ProtCryoSparc3DVariabilityDisplay(ProtCryosparcBase, ProtRefine3D):
 
         # Determinate the GPUs to use (in dependence of the cryosparc version)
         try:
-            gpusToUse = self.getGpuList()
+            if not self.useQueueForSteps() and not self.useQueue():  # not using queue system
+                gpusToUse = self.getGpuList()
+            else:  # using queue system
+                gpusToUse = False
         except Exception:
             gpusToUse = False
 

--- a/cryosparc2/protocols/protocol_cryosparc_ab.py
+++ b/cryosparc2/protocols/protocol_cryosparc_ab.py
@@ -499,7 +499,10 @@ class ProtCryoSparcInitialModel(ProtCryosparcBase, ProtInitialVolume,
         # Determinate the GPUs to use (in dependence of
         # the cryosparc version)
         try:
-            gpusToUse = self.getGpuList()
+            if not self.useQueueForSteps() and not self.useQueue():  # not using queue system
+                gpusToUse = self.getGpuList()
+            else:  # using queue system
+                gpusToUse = False
         except Exception:
             gpusToUse = False
 

--- a/cryosparc2/protocols/protocol_cryosparc_blob_picker.py
+++ b/cryosparc2/protocols/protocol_cryosparc_blob_picker.py
@@ -260,7 +260,10 @@ class ProtCryoSparcBlobPicker(ProtCryosparcBase):
         params = {'classic_mode': 'False'}
         className = 'patch_ctf_estimation_multi'
         try:
-            gpusToUse = self.getGpuList()
+            if not self.useQueueForSteps() and not self.useQueue():  # not using queue system
+                gpusToUse = self.getGpuList()
+            else:  # using queue system
+                gpusToUse = False
         except Exception:
             gpusToUse = False
 

--- a/cryosparc2/protocols/protocol_cryosparc_global_ctf_refinement.py
+++ b/cryosparc2/protocols/protocol_cryosparc_global_ctf_refinement.py
@@ -316,7 +316,10 @@ class ProtCryoSparcGlobalCtfRefinement(ProtCryosparcBase, pwprot.ProtParticles):
         # Determinate the GPUs to use (in dependence of
         # the cryosparc version)
         try:
-            gpusToUse = self.getGpuList()
+            if not self.useQueueForSteps() and not self.useQueue():  # not using queue system
+                gpusToUse = self.getGpuList()
+            else:  # using queue system
+                gpusToUse = False
         except Exception:
             gpusToUse = False
 

--- a/cryosparc2/protocols/protocol_cryosparc_helical_refinement.py
+++ b/cryosparc2/protocols/protocol_cryosparc_helical_refinement.py
@@ -303,7 +303,10 @@ class ProtCryoSparcHelicalRefine3D(ProtCryoSparc3DHomogeneousRefine):
         # Determinate the GPUs to use (in dependence of
         # the cryosparc version)
         try:
-            gpusToUse = self.getGpuList()
+            if not self.useQueueForSteps() and not self.useQueue():  # not using queue system
+                gpusToUse = self.getGpuList()
+            else:  # using queue system
+                gpusToUse = False
         except Exception:
             gpusToUse = False
 

--- a/cryosparc2/protocols/protocol_cryosparc_homogeneous_reconstruction.py
+++ b/cryosparc2/protocols/protocol_cryosparc_homogeneous_reconstruction.py
@@ -450,7 +450,10 @@ class ProtCryoSparcHomogeneousReconstruct(ProtCryosparcBase):
         # Determinate the GPUs to use (in dependence of
         # the cryosparc version)
         try:
-            gpusToUse = self.getGpuList()
+            if not self.useQueueForSteps() and not self.useQueue():  # not using queue system
+                gpusToUse = self.getGpuList()
+            else:  # using queue system
+                gpusToUse = False
         except Exception:
             gpusToUse = False
 

--- a/cryosparc2/protocols/protocol_cryosparc_homogeneous_refine.py
+++ b/cryosparc2/protocols/protocol_cryosparc_homogeneous_refine.py
@@ -676,7 +676,10 @@ class ProtCryoSparc3DHomogeneousRefine(ProtCryosparcBase):
         # Determinate the GPUs to use (in dependence of
         # the cryosparc version)
         try:
-            gpusToUse = self.getGpuList()
+            if not self.useQueueForSteps() and not self.useQueue():  # not using queue system
+                gpusToUse = self.getGpuList()
+            else:  # using queue system
+                gpusToUse = False
         except Exception:
             gpusToUse = False
 

--- a/cryosparc2/protocols/protocol_cryosparc_local_ctf_refinement.py
+++ b/cryosparc2/protocols/protocol_cryosparc_local_ctf_refinement.py
@@ -253,7 +253,10 @@ class ProtCryoSparcLocalCtfRefinement(ProtCryosparcBase, ProtParticles):
         # Determinate the GPUs to use (in dependence of
         # the cryosparc version)
         try:
-            gpusToUse = self.getGpuList()
+            if not self.useQueueForSteps() and not self.useQueue():  # not using queue system
+                gpusToUse = self.getGpuList()
+            else:  # using queue system
+                gpusToUse = False
         except Exception:
             gpusToUse = False
 

--- a/cryosparc2/protocols/protocol_cryosparc_new_3D_classification.py
+++ b/cryosparc2/protocols/protocol_cryosparc_new_3D_classification.py
@@ -697,7 +697,10 @@ class ProtCryoSparcNew3DClassification(ProtCryosparcBase):
         # Determinate the GPUs to use (in dependence of
         # the cryosparc version)
         try:
-            gpusToUse = self.getGpuList()
+            if not self.useQueueForSteps() and not self.useQueue():  # not using queue system
+                gpusToUse = self.getGpuList()
+            else:  # using queue system
+                gpusToUse = False
         except Exception:
             gpusToUse = False
 

--- a/cryosparc2/protocols/protocol_cryosparc_new_local_refine.py
+++ b/cryosparc2/protocols/protocol_cryosparc_new_local_refine.py
@@ -421,7 +421,10 @@ class ProtCryoSparcLocalRefine(ProtCryosparcBase, ProtOperateParticles):
         # Determinate the GPUs to use (in dependence of
         # the cryosparc version)
         try:
-            gpusToUse = self.getGpuList()
+            if not self.useQueueForSteps() and not self.useQueue():  # not using queue system
+                gpusToUse = self.getGpuList()
+            else:  # using queue system
+                gpusToUse = False
         except Exception:
             gpusToUse = False
 

--- a/cryosparc2/protocols/protocol_cryosparc_part_subtract.py
+++ b/cryosparc2/protocols/protocol_cryosparc_part_subtract.py
@@ -279,7 +279,10 @@ class ProtCryoSparcSubtract(ProtCryosparcBase, ProtOperateParticles):
         # Determinate the GPUs to use (in dependence of
         # the cryosparc version)
         try:
-            gpusToUse = self.getGpuList()
+            if not self.useQueueForSteps() and not self.useQueue():  # not using queue system
+                gpusToUse = self.getGpuList()
+            else:  # using queue system
+                gpusToUse = False
         except Exception:
             gpusToUse = False
 

--- a/cryosparc2/protocols/protocol_cryosparc_patch_ctf_estimation.py
+++ b/cryosparc2/protocols/protocol_cryosparc_patch_ctf_estimation.py
@@ -196,7 +196,10 @@ class ProtCryoSparcPatchCTFEstimate(ProtCryosparcBase):
         input_group_connect = {"exposures": self.micrographs.get()}
         params = {'classic_mode': 'False'}
         try:
-            gpusToUse = self.getGpuList()
+            if not self.useQueueForSteps() and not self.useQueue():  # not using queue system
+                gpusToUse = self.getGpuList()
+            else:  # using queue system
+                gpusToUse = False
         except Exception:
             gpusToUse = False
 

--- a/cryosparc2/protocols/protocol_cryosparc_sharppening.py
+++ b/cryosparc2/protocols/protocol_cryosparc_sharppening.py
@@ -204,7 +204,10 @@ class ProtCryoSparcSharppening(ProtCryosparcBase, ProtAnalysis3D):
         # Determinate the GPUs to use (in dependence of
         # the cryosparc version)
         try:
-            gpusToUse = self.getGpuList()
+            if not self.useQueueForSteps() and not self.useQueue():  # not using queue system
+                gpusToUse = self.getGpuList()
+            else:  # using queue system
+                gpusToUse = False
         except Exception:
             gpusToUse = False
 

--- a/cryosparc2/protocols/protocol_cryosparc_symmetry_expansion.py
+++ b/cryosparc2/protocols/protocol_cryosparc_symmetry_expansion.py
@@ -202,7 +202,10 @@ class ProtCryoSparcSymmetryExpansion(ProtCryosparcBase):
         # Determinate the GPUs to use (in dependence of
         # the cryosparc version)
         try:
-            gpusToUse = self.getGpuList()
+            if not self.useQueueForSteps() and not self.useQueue():  # not using queue system
+                gpusToUse = self.getGpuList()
+            else:  # using queue system
+                gpusToUse = False
         except Exception:
             gpusToUse = False
 


### PR DESCRIPTION
Before this change, the protocols were not using the GPU/s assigned by the queue system but the one/s provided in the form. Now works properly.